### PR TITLE
docs: document converting between Collectives and Organizations

### DIFF
--- a/collectives/changing-fiscal-host.md
+++ b/collectives/changing-fiscal-host.md
@@ -10,7 +10,7 @@ icon: house-chimney-medical
 
 You have the option to change to a new Fiscal Host, even after your Collective has started raising and spending money.
 
-This could be because your Collective requires less (or different) assistance. You might want to move from a generalist host to a specialized one (or vice versa). You may even decide to become an [Independent Collective](/broken/pages/pq8pncIKdGKWl7rQ1tKe) and use your own bank account and legal status.&#x20;
+This could be because your Collective requires less (or different) assistance. You might want to move from a generalist host to a specialized one (or vice versa). You may even decide to become an Organization and manage money in your own bank account. After leaving your Fiscal Host, you can convert your Collective to an Organization from **Dashboard > Settings > Advanced**. See [Converting between Collectives and Organizations](../organizations/creating-an-organization/README.md#converting-between-collectives-and-organizations) for requirements and steps.&#x20;
 
 You can switch hosts directly within the Open Collective platform.
 

--- a/organizations/creating-an-organization/README.md
+++ b/organizations/creating-an-organization/README.md
@@ -27,5 +27,51 @@ Select this option if your Collective does not currently exist on Open Collectiv
 
 [migrating-from-fiscal-host-to-an-organization.md](migrating-from-fiscal-host-to-an-organization.md "mention")
 
-Find out how to leave a host and become an Independent Collective
+Find out how to leave a host and become an Organization
+
+### Converting between Collectives and Organizations
+
+If you already have a Collective or Organization on Open Collective, you can change the account type without creating a new profile. Your URL, contribution history, and team members stay the same.
+
+Account admins can find these options under **Dashboard > Settings > Advanced**. You can also start the Collective-to-Organization flow from **Dashboard > Settings > Fiscal Host** using the **Convert this account to an Organization** link.
+
+Both conversions require [two-factor authentication](../../advanced/security-for-accounts/two-factor-authentication.md). These options are not available for private accounts.
+
+#### Convert a Collective to an Organization
+
+Use this when your group has its own legal entity and bank account, and you want to manage money on Open Collective without a Fiscal Host.
+
+Before you convert:
+
+* Your Collective must not be hosted by a Fiscal Host. If you are currently hosted, [remove your host](../../collectives/changing-fiscal-host.md) first.
+* Your balance must be zero. See [Zero Collective Balance](../../collectives/closing-a-collective/zero-collective-balance.md) for ways to empty your account.
+* Withdraw any pending applications to Fiscal Hosts.
+
+To convert:
+
+1. Go to **Dashboard > Settings > Advanced**.
+2. In the **Convert to Organization** section, click **Convert to Organization**.
+3. Enter your Organization's legal name. This should match the legal name on your bank account.
+4. Confirm the conversion. You will be prompted for two-factor authentication.
+
+The conversion enables money management on your account. After converting, connect your bank account and payment processor (such as Stripe) to start receiving contributions. See [Managing Organization Finances](../managing-organization-finances.md).
+
+If you are leaving a Fiscal Host as part of this change, see [Migrating from Fiscal Host to an Organization](migrating-from-fiscal-host-to-an-organization.md) for the full workflow, including what happens to recurring contributions.
+
+#### Convert an Organization to a Collective
+
+Use this if you converted by mistake, or if you no longer want to manage money yourself and plan to join a Fiscal Host instead.
+
+Before you convert:
+
+* Deactivate **Money Management** and **Fiscal Hosting** on your Organization, if either is enabled.
+* Your balance must be zero. Pay out remaining funds by submitting and marking expenses as paid.
+
+To convert:
+
+1. Go to **Dashboard > Settings > Advanced**.
+2. In the **Convert to Collective** section, click **Convert to Collective**.
+3. Confirm the conversion. You will be prompted for two-factor authentication.
+
+After converting, your account becomes a Collective. You will need to [apply to a Fiscal Host](../../collectives/choosing-a-fiscal-host.md) before you can raise or spend money again.
 

--- a/organizations/creating-an-organization/migrating-from-fiscal-host-to-an-organization.md
+++ b/organizations/creating-an-organization/migrating-from-fiscal-host-to-an-organization.md
@@ -14,15 +14,21 @@ Remember that once you go independent, you will no longer have the support of a 
 {% hint style="warning" %}
 You will not be able to move your Collective until you have restored your balance to zero.
 
-To find out how to do this, go to our page on [Withdrawing Collective Funds.](/broken/pages/1Jgx7U3uFL9aISk7Ua90)
+To find out how to do this, see [Zero Collective Balance](../../collectives/closing-a-collective/zero-collective-balance.md).
 {% endhint %}
 
 ### To migrate from a Fiscal Host:
 
-1. Ensure that your Collective's balance is empty.
-2. Go to the "Fiscal Host" option in your "Settings" menu and select "Remove Host"
-3. Click on "Convert this account to an Organization" and fill up the form. Make sure your Legal Name is the same as the bank account owner for your Organization by checking in the "Info" section of "Settings" (you do not need to change your display name)
-4. Connect your bank account and Stripe account in the onboarding screen
+1. Ensure that your Collective's balance is empty. See [Zero Collective Balance](../../collectives/closing-a-collective/zero-collective-balance.md) for options.
+2. Go to **Dashboard > Settings > Fiscal Host** and select **Remove Host**.
+3. Convert your Collective to an Organization:
+   * From **Dashboard > Settings > Fiscal Host**, click **Convert this account to an Organization**, or
+   * Go to **Dashboard > Settings > Advanced**, open the **Convert to Organization** section, and click **Convert to Organization**.
+4. Enter your Organization's legal name. This should match the legal name on your bank account (check **Dashboard > Settings > Info** if needed). You do not need to change your display name.
+5. Confirm the conversion. You will be prompted for two-factor authentication.
+6. Connect your bank account and Stripe account in the onboarding screen.
+
+For general requirements and the reverse conversion (Organization back to Collective), see [Converting between Collectives and Organizations](README.md#converting-between-collectives-and-organizations).
 
 {% hint style="warning" %}
 Once you move your Collective away from your Fiscal Host, your recurring contributors will be contacted by email and asked to reconfirm their credit card details upon the integration of your new Stripe account.

--- a/organizations/organizations.md
+++ b/organizations/organizations.md
@@ -27,11 +27,17 @@ You may seek support from the Open Collective team on issues related to the plat
 If you are in any doubt about your ability to manage your funds and admin effectively, we strongly recommend [applying to a Fiscal Host](../collectives/choosing-a-fiscal-host.md) instead.
 {% endhint %}
 
+### Converting back to a Collective
+
+If you no longer want to manage money as an Organization, you can convert your account back to a Collective from **Dashboard > Settings > Advanced**. You must first deactivate money management and fiscal hosting, and bring your balance to zero.
+
+See [Creating an Organization](creating-an-organization/README.md#converting-between-collectives-and-organizations) for the full steps and requirements.
+
 ### **Find out more**
 
 [creating-an-organization](creating-an-organization/ "mention")
 
-Find out how to set up an Organization from scratch, or move it from elsewh
+Find out how to set up an Organization from scratch, convert an existing Collective, or move away from a Fiscal Host
 
 
 


### PR DESCRIPTION
## Summary
- Document Collective-to-Organization and Organization-to-Collective conversion on existing pages
- Update fiscal-host migration steps to match current Advanced settings UI
- Replace broken links with current documentation paths

## Pages
- `organizations/creating-an-organization/README.md` - primary conversion guide (both directions)
- `organizations/organizations.md` - converting back to a Collective
- `organizations/creating-an-organization/migrating-from-fiscal-host-to-an-organization.md` - updated migration workflow
- `collectives/changing-fiscal-host.md` - link to conversion when leaving a host

## Verified against
- opencollective-frontend: `components/edit-collective/Form.js`, `ConvertToOrganization.tsx`, `ConvertToCollective.tsx`, `sections/Host.js`

## Test plan
- [ ] Read updated pages on GitBook preview
- [ ] Confirm steps match current UI (Dashboard > Settings > Advanced)
- [ ] Verify cross-links resolve correctly