### PR TITLE
docs: dashboard navigation guide and sidebar path updates

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -129,6 +129,7 @@
   * [Fiscal Host Security](fiscal-hosts/setting-up-a-fiscal-host/fiscal-host-security.md)
   * [Fiscal Host Policies](fiscal-hosts/setting-up-a-fiscal-host/fiscal-host-policies.md)
 * [Fiscal Host Overview Dashboard](fiscal-hosts/fiscal-host-overview-dashboard.md)
+* [Dashboard Navigation](fiscal-hosts/dashboard-navigation.md)
 * [Managing your Collectives](fiscal-hosts/managing-your-collectives/README.md)
   * [Hosted Collectives](fiscal-hosts/managing-your-collectives/hosted-collectives.md)
   * [Collective Applications](fiscal-hosts/managing-your-collectives/collective-applications.md)

--- a/advanced/preview-features.md
+++ b/advanced/preview-features.md
@@ -18,7 +18,7 @@ To find and choose features:
 3. Find the Preview Features option on the menu
 4. Select the features you would like to preview, and switch them on using the toggle button
 
-By clicking the button, the feature preview will be enabled on your account. If you want to change back for any reason, toggle the button off again, and your interface will revert to the original state.&#x20;
+By clicking the button, the feature preview will be enabled on your account. If you want to change back for any reason, toggle the button off again, and your interface will revert to the original state.
 
 {% hint style="info" %}
 The features available in the preview features menu will vary depending on the type of role you hold on the platform. For example, admins may see different options to individual users.
@@ -28,6 +28,66 @@ The features available in the preview features menu will vary depending on the t
 
 Every feature in the Preview Features menu is at a stage where we're happy to share it with users. They may, however, change without notice as we receive and adapt to user feedback.
 
-We would always like to hear from you about any improvements you’d like to see, but we’re particularly interested in feedback regarding new features and updates.
+We would always like to hear from you about any improvements you'd like to see, but we're particularly interested in feedback regarding new features and updates.
 
 If you want us to change or fix any part of the feature you're currently previewing, please get in touch via the link in the menu box or [contact us](https://opencollective.com/contact).
+
+## Available preview features
+
+### Sidebar Reorganization Incoming/Outgoing (public beta)
+
+Renames **Expenses** to **Outgoing Money** and **Contributions** to **Incoming Money**, and moves cross-account items to the appropriate groups.
+
+**Outgoing Money** sub-pages (fiscal hosts):
+
+* **Pay Disbursements** - expenses ready to pay
+* **Paid Disbursements** - expenses already paid
+* **Approve Payment Requests** - expenses awaiting approval
+* **All Payment Requests** - full expense list
+* **Outgoing Contributions** - contributions this account made to other accounts
+
+**Incoming Money** sub-pages (fiscal hosts):
+
+* **Incoming Contributions** - contributions received by hosted accounts
+* **Expected Funds** - pending offline or bank contributions
+* **Incomplete Contributions** - contributions needing follow-up
+* **Issued Payment Requests** - payment requests submitted by this account
+
+See [Dashboard Navigation](../fiscal-hosts/dashboard-navigation.md) for a mapping from older sidebar labels.
+
+### Keyboard Shortcuts (public beta)
+
+Navigate expense workflows faster with keyboard shortcuts.
+
+**On the expenses dashboard:**
+
+| Key | Action |
+| --- | ------ |
+| J | Select the next expense |
+| K | Select the previous expense |
+| P | Pay selected expense (if ready to pay) |
+| S | Check security alerts for selected expense |
+| Enter | Open expense details |
+
+**On expense details:**
+
+| Key | Action |
+| --- | ------ |
+| Left / Right arrow | Navigate through attachments |
+| H | Put selected expense on hold |
+| I | Mark selected expense as incomplete |
+| P | Pay selected expense (if ready to pay) |
+| E | Enter edit mode |
+| Esc | Close expense details |
+
+### Table Quick Actions (public beta)
+
+Shows action buttons on table rows when you hover over them, so you can perform common actions without opening the row menu.
+
+### Async Exports (closed beta)
+
+Enables background processing for large data exports on organization accounts. Exports run asynchronously and you are notified when the download is ready. See [Exporting Your Data](exporting-your-data.md).
+
+### Crowdfunding Redesign (public beta)
+
+Preview of redesigned crowdfunding and profile pages, including separate fundraising and storytelling views and improved goal tracking. See the [blog post](https://blog.opencollective.com/open-collective-crowdfunding-redesign/) for details.

--- a/fiscal-hosts/chart-of-accounts.md
+++ b/fiscal-hosts/chart-of-accounts.md
@@ -54,7 +54,7 @@ In order for transactions to be associated with the appropriate categories, they
 
 ### Expense Categorization
 
-To categorize an expense, navigate to Fiscal Host Dashboard > Expenses. Find the specific expense you would like to categorize and click on the grey drop down next to where it says “Category” and select or search for the specific category that applies.&#x20;
+To categorize an expense, navigate to Fiscal Host Dashboard > Outgoing Money > All Payment Requests. Find the specific expense you would like to categorize and click on the grey drop down next to where it says “Category” and select or search for the specific category that applies.&#x20;
 
 Alternatively, when an expense submitter submits an expense, they are able to select from your list of categories.&#x20;
 
@@ -64,4 +64,4 @@ Contact us if you're interested in using AI to help automate the expense categor
 
 ### Contribution Categorization
 
-To categorize a contribution, navigate to Fiscal Host Dashboard > Contributions. Find the specific contribution that you would like to categorize, click the three dots icon on the right, click View Details, click the grey drop down and select or search for the category that you would like to apply.
+To categorize a contribution, navigate to Fiscal Host Dashboard > Incoming Money > Incoming Contributions. Find the specific contribution that you would like to categorize, click the three dots icon on the right, click View Details, click the grey drop down and select or search for the category that you would like to apply.

--- a/fiscal-hosts/dashboard-navigation.md
+++ b/fiscal-hosts/dashboard-navigation.md
@@ -1,0 +1,74 @@
+---
+description: >-
+  Reference for the fiscal host and organization dashboard sidebar, including
+  how new Incoming Money and Outgoing Money menus map to older labels.
+icon: map
+---
+
+# Dashboard Navigation
+
+The dashboard sidebar groups tasks by what you are trying to do. The layout depends on your account type (individual, collective, organization, or fiscal host) and your role on that account.
+
+If you use the **Sidebar Reorganization Incoming/Outgoing** preview feature (enabled by default for many accounts), money-in and money-out sections use the labels below. See [Preview Features](../advanced/preview-features.md) to turn this on or off.
+
+## Account switcher
+
+Use the account switcher in the top-left corner to move between profiles where you hold a role (personal account, collective admin, organization admin, fiscal host admin, and so on). The sidebar updates to show tasks relevant to the selected account.
+
+## Sidebar groups by account type
+
+### Fiscal hosts and organizations with money management
+
+| Sidebar group | Pages | Typical tasks |
+| ------------- | ----- | --------------- |
+| **Overview** | Overview | Balances, setup checklist, key metrics |
+| **Accounts** | Accounts | Projects, events, and connected accounts (collectives and organizations) |
+| **Outgoing Money** | Pay Disbursements, Paid Disbursements, Approve Payment Requests, All Payment Requests, Outgoing Contributions | Review, approve, and pay expenses; track outgoing contributions from this account |
+| **Incoming Money** | Incoming Contributions, Expected Funds, Incomplete Contributions, Issued Payment Requests | Track contributions received, pending bank transfers, and payment requests you submitted |
+| **Internal Transfers** | Internal Transfers | Move funds between accounts you manage (preview) |
+| **Funds & Grants** | Hosted Funds, Hosted Grant Requests, Grants, Approve Grant Requests | Manage grant programs and hosted funds |
+| **Ledger** | Transactions, Bank Account Sync, CSV Imports | Full transaction history and off-platform reconciliation |
+| **Hosting** | Hosted Collectives, Applications | Manage hosted collectives and incoming applications |
+| **People** | People | Search accounts, roles, KYC status, and exports |
+| **Vendors** | Vendors | Vendor directory for your host |
+| **Reports** | Transactions, Expenses, Contributions | Downloadable reports |
+| **Settings** | Info, Fiscal Hosting, Receiving Money, Sending Money, and more | Account configuration |
+
+### Hosted collectives
+
+Hosted collectives see a smaller set of sections focused on fundraising and spending: **Overview**, **Outgoing Money** (or **Expenses** without the preview), **Incoming Money** (or **Contributions**), **Transactions**, **Contributors**, **Tiers**, **Team**, and **Settings**.
+
+### Individual accounts
+
+Individuals typically see **Overview**, **Payment Requests** (or **Expenses**), **Contributions** (outgoing contributions you made), **Transactions**, and **Settings**.
+
+## Old label to new label reference
+
+Use this table when following older documentation or support articles that reference previous sidebar names.
+
+| Previous label | New label (with sidebar reorg preview) | Notes |
+| -------------- | ---------------------------------------- | ----- |
+| **Expenses** (fiscal host) | **Outgoing Money** | Host expense workflows are split across sub-pages |
+| Expenses - ready to pay | **Outgoing Money > Pay Disbursements** | Expenses approved and awaiting payment |
+| Expenses - all | **Outgoing Money > All Payment Requests** | Full expense list |
+| Expenses - approve | **Outgoing Money > Approve Payment Requests** | Expenses pending collective or host approval |
+| **Contributions** (fiscal host) | **Incoming Money** | Received money and related workflows |
+| Contributions - received | **Incoming Money > Incoming Contributions** | Financial contributions to hosted accounts |
+| **Expected Funds** | **Incoming Money > Expected Funds** | Pending offline or bank contributions |
+| **Incomplete Contributions** | **Incoming Money > Incomplete Contributions** | Contributions that need follow-up |
+| Contributions - from this account | **Outgoing Money > Outgoing Contributions** | Contributions this account made to others |
+| Expenses - submitted by this account | **Incoming Money > Issued Payment Requests** | Payment requests you submitted |
+| **Collectives** | **Hosting > Hosted Collectives** | List of hosted collectives |
+| **Contributors** (on hosted collective) | **Contributors** | Unchanged for hosted collectives |
+| **Contributors** / community (fiscal host) | **People** | Host-wide account directory |
+| **Transactions** (with money management) | **Ledger > Transactions** | Full ledger view |
+| **Payment Requests** (self-hosted organization) | **Outgoing Money > Payment Requests** | Organizations paying their own expenses |
+
+{% hint style="info" %}
+**Settings** paths are unchanged. For example, **Dashboard > Settings > Receiving Money** works the same regardless of the sidebar preview.
+{% endhint %}
+
+## Related documentation
+
+* [Your Dashboard](../getting-started/your-dashboard.md) - getting started with the dashboard
+* [Preview Features](../advanced/preview-features.md) - enable sidebar reorganization and other previews

--- a/fiscal-hosts/managing-your-collectives/agreements.md
+++ b/fiscal-hosts/managing-your-collectives/agreements.md
@@ -27,7 +27,7 @@ Navigate to your Fiscal Host Dashboard > Agreements. Click "Add New +" in the to
 * **Expiration date:** Use this field to indicate if an Agreement is only relevant up to a specific date.&#x20;
 * **Notes:** Add any additional information necessary for the specific Agreement. Because the Agreement file is optional, Fiscal Host admins can also use this field alone to define an Agreement if there are no related documents.
 
-Alternatively, you can navigate to your Fiscal Host Dashboard > Hosting > Hosted Collectives and find the specific Collective that you'd like to add an Agreement to. Click on the Collective, and at the bottom of the side page click More Actions > Add Agreement.
+Alternatively, navigate to your Fiscal Host Dashboard > Hosting > Hosted Collectives, find the specific Collective that you'd like to add an Agreement to, click on the Collective, and at the bottom of the side panel click More Actions > Add Agreement.
 
 <figure><img src="../../.gitbook/assets/image (55).png" alt="Screen shot of the &#x22;Add Agreement&#x22; page."><figcaption></figcaption></figure>
 

--- a/fiscal-hosts/managing-your-collectives/freezing-a-collective.md
+++ b/fiscal-hosts/managing-your-collectives/freezing-a-collective.md
@@ -34,7 +34,7 @@ If a Collective is frozen, the Collective admins will be notified via an email n
 ## Freeze a Collective:
 
 1. Make sure you have set your profile to your Fiscal Host Admin account
-2. Go to your Fiscal Host Dashboard > Collectives > Hosted Collectives&#x20;
+2. Go to your Fiscal Host Dashboard > Hosting > Hosted Collectives&#x20;
 3. Locate the Collective you wish to freeze in your list of hosted Collectives
 4. Click on the three dots to the bottom right of the Collective's card (see image)
 5. Choose "Freeze"

--- a/fiscal-hosts/managing-your-collectives/hosted-collectives.md
+++ b/fiscal-hosts/managing-your-collectives/hosted-collectives.md
@@ -9,7 +9,7 @@ icon: people-roof
 
 Open Collective makes it easy to keep track of all the Collectives that you host.
 
-To view a list of all your Hosted Collectives, navigate to your Fiscal Host’s Dashboard > Collectives.
+To view a list of all your Hosted Collectives, navigate to your Fiscal Host’s Dashboard > Hosting > Hosted Collectives.
 
 #### Search
 

--- a/fiscal-hosts/receiving-money/adding-funds-manually.md
+++ b/fiscal-hosts/receiving-money/adding-funds-manually.md
@@ -10,7 +10,7 @@ icon: money-check-dollar-pen
 
 You can manually add funds to a Collective. This is useful when you have received a contribution for a Collective outside the Open Collective platform (via bank transfer, Patreon, Eventbrite, or another service) and want to apply it to a Collective's budget.&#x20;
 
-1. Navigate to your Fiscal Host Dashboard > Collectives > Hosted Collectives
+1. Navigate to your Fiscal Host Dashboard > Hosting > Hosted Collectives
 2. Use the search bar to find the Collective you want to add funds to
 3. Click on the three dots > Add funds <br>
 

--- a/fiscal-hosts/receiving-money/expected-funds.md
+++ b/fiscal-hosts/receiving-money/expected-funds.md
@@ -13,11 +13,11 @@ There are two types of expected funds on the platform:
 1. The first are automatically generated when contributors use the “bank transfer” payment method and then manually complete payment at a later time.
 2. The other are pending contributions created by a Fiscal Host to track expected funds as a consequence of fund-raising efforts by either the Fiscal Host or Collective. Documenting expected incoming contributions will make it easier for you to track them down and reconcile them when they appear in your bank account.
 
-They can be found in your Fiscal Host Dashboard > Expected Funds.
+They can be found in your Fiscal Host Dashboard > Incoming Money > Expected Funds.
 
 ## Recording Expected Funds
 
-When you become aware of expected funds (for example, when notified by a Collective administrator), you can create a new pending contribution. Go to your Fiscal Host Dashboard > Expected Funds. At the top of the screen, click “Create +”
+When you become aware of expected funds (for example, when notified by a Collective administrator), you can create a new pending contribution. Go to your Fiscal Host Dashboard > Incoming Money > Expected Funds. At the top of the screen, click “Create +”
 
 The form is divided into three sections:
 

--- a/getting-started/your-dashboard.md
+++ b/getting-started/your-dashboard.md
@@ -7,49 +7,69 @@ icon: gauge-simple-low
 
 # Your Dashboard
 
-When you log in to your account, you will automatically be directed to your Open Collective Dashboard.
+When you log in to your account, you are directed to your Open Collective Dashboard.
 
-The Dashboard is a space that helps you complete all your tasks on Open Collective, whether you’re acting as an individual or an admin of a larger group.
+The Dashboard is where you complete tasks on Open Collective, whether you are acting as an individual, a collective admin, an organization admin, or a fiscal host admin.
 
 ### Navigating your Dashboard
 
-When you first arrive, your Dashboard will be set to your personal account. This will show you a range of tasks that you can perform with this account.
+When you first arrive, your Dashboard shows your **personal account**. From here you can:
 
-These include:
+* Review recent activity on your account
+* View and track payment requests you have submitted
+* View contributions you have made on the platform
+* Update account settings such as email, security, and payment methods
 
-* Searching recent activity relating to your account&#x20;
-* Viewing and tracking the expenses you have submitted&#x20;
-* Viewing the contributions you have made on the platform&#x20;
-* Changing your account settings, such as your email address, security info, and so on
-
-You can receive updates on specific Collectives and Fiscal Hosts by navigating to their page and clicking Follow under their name.&#x20;
+You can follow specific collectives and fiscal hosts from their public profile pages using the **Follow** button under their name.
 
 <figure><img src="../.gitbook/assets/image (75).png" alt="A screenshot of a Collective&#x27;s profile with the Follow button emphasized."><figcaption></figcaption></figure>
 
-You can review the latest updates from the Open Collective platform by clicking the megaphone in the top-right of the page, next to the search bar.&#x20;
+Platform announcements appear when you click the megaphone icon in the top-right corner, next to the search bar.
 
 {% hint style="info" %}
-Suppose you have been invited to be a team member or admin of a Collective, Organization, or Fiscal Host. In that case, you will receive a notification on your Dashboard when you are logged in, under your profile.
+If you are invited to join a collective, organization, or fiscal host as a team member or admin, you receive a notification on your Dashboard while logged in.
 {% endhint %}
 
-You can also click your profile photo in the top right corner to bring up additional account settings, including:
+Click your profile photo in the top-right corner for additional options:
 
-* Viewing your profile&#x20;
-* Selecting preview features&#x20;
-* Navigating the Open Collective homepage, docs, or support pages
+* View your public profile
+* Enable [Preview Features](../advanced/preview-features.md)
+* Open the Open Collective homepage, documentation, or support pages
 
 ### Switching between profiles
 
-If you click on the account switcher in the top left menu with your "personal account” profile image on it, you will find a list of all the roles you hold on Open Collective (if any).
+Click the **account switcher** in the top-left corner (showing your current profile image) to see every account where you hold a role.
 
-This allows you to switch your Dashboard to other roles, such as:
+Switch to another profile to work as:
 
-* An admin of a Collective&#x20;
-* An admin of an Organization&#x20;
-* An admin of a Fiscal Host
+* A collective admin
+* An organization admin
+* A fiscal host admin
 
-This will change the menu to show options that are relevant to the tasks you need to do in those roles.
+The sidebar updates to show sections relevant to that role. Fiscal hosts and organizations with money management see grouped menus such as **Outgoing Money**, **Incoming Money**, **Ledger**, **Hosting**, and **People**. See [Dashboard Navigation](../fiscal-hosts/dashboard-navigation.md) for a full reference and mapping from older sidebar labels.
+
+### Sidebar layout (preview)
+
+Many accounts can enable **Sidebar Reorganization Incoming/Outgoing** from Preview Features. When enabled:
+
+* **Expenses** becomes **Outgoing Money**, with sub-pages for paying, approving, and listing payment requests
+* **Contributions** becomes **Incoming Money**, with sub-pages for received contributions, expected funds, and incomplete contributions
+* Cross-account items move to the group that matches the money direction (for example, payment requests you submitted appear under **Incoming Money > Issued Payment Requests**)
+
+This preview is in public beta and may become the default layout. You can toggle it off from Preview Features if you prefer the previous labels.
+
+### Common dashboard paths
+
+| Task | Where to go |
+| ---- | ----------- |
+| Pay or approve expenses (fiscal host) | **Outgoing Money** (see sub-pages in [Dashboard Navigation](../fiscal-hosts/dashboard-navigation.md)) |
+| Review received contributions | **Incoming Money > Incoming Contributions** |
+| Manage hosted collectives | **Hosting > Hosted Collectives** |
+| View all transactions | **Ledger > Transactions** (organizations and hosts) or **Transactions** (collectives) |
+| Account settings | **Settings** (any subsection) |
+| Team members | **Team** |
+| Fundraising tiers | **Tiers** |
 
 {% hint style="success" %}
-We are interested in hearing from you about any comments or requests you may have. If you have suggestions, please let us know by clicking the Give Feedback option in your Dashboard or using [this link.](https://opencollective.com/redirect?url=https%3A%2F%2Fdocs.google.com%2Fforms%2Fd%2F1-WGUCUF_i5HPS6AsN8kTfqofyt0q0HB-q7na4cQL788%2Fviewform)
+We welcome feedback on the dashboard. Use **Give Feedback** in your Dashboard or [this form](https://opencollective.com/redirect?url=https%3A%2F%2Fdocs.google.com%2Fforms%2Fd%2F1-WGUCUF_i5HPS6AsN8kTfqofyt0q0HB-q7na4cQL788%2Fviewform).
 {% endhint %}


### PR DESCRIPTION
## Summary
- Add Dashboard Navigation reference page mapping old sidebar labels to Incoming/Outgoing Money groups
- Rewrite Your Dashboard and expand Preview Features (sidebar reorg, keyboard shortcuts, table quick actions)
- Update stale fiscal host Dashboard paths in chart of accounts, hosting, and expected funds docs

## Pages
- `fiscal-hosts/dashboard-navigation.md` (new)
- `getting-started/your-dashboard.md`
- `advanced/preview-features.md`
- `fiscal-hosts/chart-of-accounts.md`
- `fiscal-hosts/managing-your-collectives/hosted-collectives.md`
- `fiscal-hosts/receiving-money/expected-funds.md`
- `fiscal-hosts/receiving-money/adding-funds-manually.md`
- `fiscal-hosts/managing-your-collectives/freezing-a-collective.md`
- `fiscal-hosts/managing-your-collectives/agreements.md`
- `SUMMARY.md`

## Verified against
- opencollective-frontend: `components/dashboard/menu-items.ts`, `lib/preview-features.tsx`

## Test plan
- [ ] Read updated pages on GitBook preview
- [ ] Confirm sidebar paths match current UI with sidebar reorg preview enabled
- [ ] Confirm old-to-new mapping table is accurate