### PR TITLE
docs: cancel/refund flows and annual payment receipts

### DIFF
--- a/collectives/raising-money/rejecting-and-refunding-financial-contributions.md
+++ b/collectives/raising-money/rejecting-and-refunding-financial-contributions.md
@@ -7,38 +7,83 @@ icon: coins
 
 # Rejecting and Refunding  Financial Contributions
 
-Our moderation features give you control over who is able to donate to your Collective.&#x20;
+Our moderation features give you control over who is able to donate to your Collective.
 
-You can choose to reject and refund any contribution and even block contributions from selected accounts or groups.
+You can refund mistaken contributions, reject unwanted donations, cancel recurring contributions, and block contributions from selected accounts or groups.
 
 You can reject financial contributions for any reason, but if you want to clarify the types of donations you will not accept, you can outline your terms in your Contribution Policy.
 
-Navigate to your Collective's Dashboard > Settings > Policies.&#x20;
-
-### Rejecting financial contributions
-
-You can reject a donation from any person or group.
-
-This will:
-
-* refund the financial contributor
-* cancel any future recurring contribution
-* remove their membership from your Collective so they are not listed as a sponsor
+Navigate to your Collective's Dashboard > Settings > Policies.
 
 {% hint style="info" %}
-If enabled by the Fiscal Host, Collective admins can reject and/or refund financial contributions for up to 30 days after they are made. Fiscal Host admins have the capacity to refund contributions indefinitely. We recommend Fiscal Hosts have their own refund policy. You can learn more about this in the [Fiscal Host Policies](../../fiscal-hosts/setting-up-a-fiscal-host/fiscal-host-policies.md) section.&#x20;
+If enabled by the Fiscal Host, Collective admins can reject and/or refund financial contributions for up to 30 days after they are made. Fiscal Host admins can refund contributions indefinitely. We recommend Fiscal Hosts have their own refund policy. See [Fiscal Host Policies](../../fiscal-hosts/setting-up-a-fiscal-host/fiscal-host-policies.md).
 {% endhint %}
+
+## Refund vs reject vs cancel
+
+These actions serve different purposes:
+
+| Action | What it does | When to use it |
+| ------ | ------------ | -------------- |
+| **Refund** | Returns money to the contributor. Optionally cancels future recurring charges and/or removes the contributor from your profile. | A mistaken or duplicate charge, or when you need to return funds without treating the contributor as banned. |
+| **Reject** | Refunds the charge, cancels recurring contributions, removes the contributor from your Collective, and marks the contribution as rejected. | You do not want this person or group associated with your Collective. |
+| **Cancel contribution** | Stops future recurring charges only. Does not refund past charges. | A contributor wants to stop giving, or you need to end a subscription without refunding history. |
+
+{% hint style="warning" %}
+If you only need to refund a mistaken transaction, use **Refund** rather than **Reject**. The reject flow always removes the contributor from your Collective.
+{% endhint %}
+
+## Refunding a contribution
+
+1. Navigate to your Collective's Dashboard > Ledger > Transactions (or **Transactions** if your account does not show a Ledger group).
+2. Find the contribution.
+3. Click **Refund**.
+4. Review the refund allocation (amount returned to the contributor, amounts deducted from the collective, host, and platform).
+5. Optionally enable:
+   * **Cancel recurring contribution** - stops future charges (enabled by default when available)
+   * **Remove contributor from Collective** - hides them from your public profile and exports while keeping the ledger entry
+   * **Send custom message to contributor**
+6. Confirm the refund.
+
+If the collective balance is insufficient to cover the refund, host admins may see an **Allow negative balance** option to process the refund anyway.
+
+## Rejecting a contribution
+
+Rejecting a contribution:
+
+* Refunds the financial contributor
+* Cancels any future recurring contribution
+* Removes their membership from your Collective so they are not listed as a sponsor
+* Displays the contribution as rejected
 
 To reject a contribution:
 
-1. Navigate to your Collective's Dashboard >  Transactions
-2. Find the contribution
-3. Click "View Details"
-4. Click the “Reject” button.
+1. Navigate to your Collective's Dashboard > Ledger > Transactions (or **Transactions**).
+2. Find the contribution.
+3. Click **Reject**.
+4. Optionally add a message explaining your decision.
+5. Confirm.
 
-You can also send them a message, explaining the reasons for your decision.&#x20;
+## Canceling a recurring contribution (without refunding)
 
-Confirm your decision, and your budget will be updated to show the rejection as well as the refund.
+Hosts and contributors can cancel recurring contributions without refunding past charges.
+
+**As a fiscal host admin:**
+
+1. Navigate to Fiscal Host Dashboard > Incoming Money > Incoming Contributions.
+2. Open the contribution or use the row actions menu.
+3. Click **Cancel contribution**.
+4. Optionally remove the contributor from the collective profile or send them a custom message.
+5. Confirm.
+
+**As a contributor:**
+
+1. Navigate to your Dashboard > Outgoing Contributions (or **Contributions** without the sidebar reorg preview).
+2. Find the recurring contribution and cancel it.
+
+See [Making a Recurring Contribution](../../giving-to-collectives/making-a-recurring-contribution.md) for contributor-side steps.
+
+Fiscal host admins should see [Processing Refunds](../../fiscal-hosts/processing-refunds.md) for host-level refund details.
 
 ### Rejecting categories of financial contributor
 
@@ -53,13 +98,13 @@ We offer the option to block the following groups:
 * Essay writing services
 * Affiliate/review services
 
-If you wish to block one or more of these, navigate to your Collective's Dashboard > Settings > Policies and find the drop-down under “Rejected Categories”.
+If you wish to block one or more of these, navigate to your Collective's Dashboard > Settings > Policies and find the drop-down under "Rejected Categories".
 
 Once you have made your selection, any account that has been tagged by the Open Collective team as belonging to one of these categories will not be able to contribute to your Collective.
 
-They will be notified that they are blocked from contributing when they navigate to your “Contribute To…” page.
+They will be notified that they are blocked from contributing when they navigate to your "Contribute To..." page.
 
-If you would like to let potential contributors to your Collective know upfront what your contribution policy is, and what kinds of contributions you may not accept, you can also do this in the 'Policies' section of the Collective menu. This will be displayed in the contribution flow as well.
+If you would like to let potential contributors to your Collective know upfront what your contribution policy is, and what kinds of contributions you may not accept, you can also do this in the Policies section of the Collective menu. This will be displayed in the contribution flow as well.
 
 {% hint style="warning" %}
 It is against Open Collective's community guidelines and moderation policy for a contributor to create a new account to get around the category filter. If this happens, [please report it to us](https://opencollective.com/contact).

--- a/fiscal-hosts/processing-refunds.md
+++ b/fiscal-hosts/processing-refunds.md
@@ -15,25 +15,46 @@ After that point, donations can only be refunded by Fiscal Host admins.
 Open Collective has a platform wide [Refund Policy](../giving-to-collectives/requesting-refunds/refund-policy.md). Fiscal Host admins should familiarize themselves with this policy before they develop their own.
 {% endhint %}
 
-#### Set Refund Policy:
+## Set refund policy
 
 All Fiscal Hosts are encouraged to have a public refund policy. You can add a refund policy by:
 
 * Navigating to your Fiscal Host's Dashboard > Settings > Policies
 * Adding your Refund Policy or a link to it under Contributions or Expenses Policy sections.
 
-#### Refund a Donation:&#x20;
+## Refund a donation
 
-* Go to you host dashboard and **Ledger** section.&#x20;
-* Under the **Ledger** section choose the **Transactions** section.&#x20;
-* Find the contribution that you want to refund and click on it to open the drawer on your right hand side.&#x20;
-* You will find a refund button at the top of the drawer along with all the transaction details.&#x20;
-* Click refund and confirm the operation.
+1. Go to your Fiscal Host Dashboard > Ledger > Transactions.
+2. Find the contribution you want to refund.
+3. Click **Refund** on the transaction row.
+4. Review the **Refund contribution charge** modal:
+   * **Contribution detail** - contributor, destination account, amount, and date
+   * **Refund allocation** - how the refund is split between the contributor, collective balance, host balance, platform fees, payment processor fees, platform tips, and tax
+5. If the collective balance is insufficient, you may need to check **Allow negative balance** to proceed. The collective balance will go negative until additional contributions are received.
+6. Optionally:
+   * **Cancel recurring contribution** - stops future charges (on by default when available)
+   * **Remove contributor from Collective** - hides them from the public profile
+   * **Send custom message to contributor**
+7. Confirm the refund.
+
+Stripe and PayPal contribution charges open the full refund modal with allocation details. Other payment methods may show a simpler confirmation dialog.
 
 {% hint style="info" %}
-For contributions that were made using a Stripe enabled payment method, the funds should automatically be returned to the contributor. For other payment methods, we recommend [inviting the user to submit an expense](../collectives/spending-money/inviting-a-third-party-to-submit-an-expense.md).&#x20;
+For contributions made using Stripe, funds are automatically returned to the contributor. For other payment methods, we recommend [inviting the user to submit an expense](../collectives/spending-money/inviting-a-third-party-to-submit-an-expense.md).
 {% endhint %}
 
+## Cancel recurring without refunding
 
+To stop future charges without refunding past payments:
 
-The process for refunding contributions differs slightly depending on what the original payment method used was. If someone made their contribution with Stripe, the refund will be processed automatically after you confirm the operation. If the payment was originally made manually extra steps are needed.
+1. Navigate to Fiscal Host Dashboard > Incoming Money > Incoming Contributions.
+2. Open the contribution and click **Cancel contribution**.
+3. Optionally remove the contributor from the collective profile or send a custom message.
+
+## Reject vs refund
+
+Use **Reject** only when you want to remove a contributor from a collective entirely. Reject refunds the charge, cancels recurring contributions, and marks the contribution as rejected.
+
+If you only need to correct a mistaken charge, use **Refund** instead. See [Rejecting and Refunding Financial Contributions](../collectives/raising-money/rejecting-and-refunding-financial-contributions.md).
+
+The process for refunding contributions differs slightly depending on the original payment method. Stripe refunds process automatically after you confirm. Manual payment methods may require additional steps.

--- a/giving-to-collectives/making-a-recurring-contribution.md
+++ b/giving-to-collectives/making-a-recurring-contribution.md
@@ -59,7 +59,7 @@ It is also possible that your bank’s verification services are not working pro
 
 If you wish to change or remove a recurring contribution:
 
-1. Navigate to your Dashboard > Contributions.&#x20;
+1. Navigate to your Dashboard > Outgoing Contributions (or **Contributions** if you have not enabled the sidebar reorganization preview).&#x20;
 2. Use the account switcher to select the account you are using to make the payments. (If you are giving from a Collective or Organization, you will also need to select the “From Name” subpage)
 3. You should then be able to edit or cancel your recurring payments to the Collectives you support.
 

--- a/giving-to-collectives/managing-receipts.md
+++ b/giving-to-collectives/managing-receipts.md
@@ -7,43 +7,43 @@ icon: receipt
 
 # Managing Receipts
 
-You can view a record of all the contributions you have made to Collectives in your Open Collective account.
-
-This means you can search payments by Collective or time period and download your receipts.
+You can view a record of all the contributions you have made to Collectives in your Open Collective account and download consolidated receipts by month or year.
 
 {% hint style="warning" %}
 **Is my contribution tax deductible?**
 
-This depends on the status of the collective’s Fiscal Host. If the host has tax-exempt status, your contribution may be tax-deductible. If in doubt, reach out to the Fiscal Host for confirmation.
+This depends on the status of the collective's Fiscal Host. If the host has tax-exempt status, your contribution may be tax-deductible. If in doubt, reach out to the Fiscal Host for confirmation.
 {% endhint %}
 
-### Finding your receipts
+## Who can access payment receipts
 
-There are two ways that you can locate and download your receipts.
+Payment receipts are available for **individual** and **organization** accounts that are not private. Navigate to **Dashboard > Settings > Payment Receipts**.
 
 If you are searching your account for a transaction, make sure you are signed in with the same email address you used to make the contribution.
 
-### Searching your account for receipts
+## Download consolidated receipts
 
-To find a list of your receipts, navigate to your Dashboard > Settings > Payment Receipts.
+1. Navigate to your Dashboard > Settings > Payment Receipts.
+2. Select a **Time period**:
+   * **Past 12 months** (default) - rolling window of the last twelve calendar months
+   * A specific **year** - when you have contributions in that year
+3. Receipts are grouped by **Fiscal Host**, then by month. Each card shows the host name, month, transaction count, and a **Download receipt** button.
+4. For past years (not the current year and not Past 12 months), an **Annual Receipts** section appears with one download per fiscal host covering the full year, followed by a monthly breakdown.
 
-You will then be able to search a list of all your contributions. You can:
+If no contributions exist in the selected period, you will see "No receipts available in this period."
 
-* Use the Search function to find a specific transaction
-* Use the Download Receipts option to download all receipts from a specific time period
+## Download a receipt from a collective budget
 
-### Searching a Collective’s page for your transaction
+You can also find individual receipts from a collective's public budget:
 
-You can also find your receipt by searching the Collective’s budget.
-
-1. Ensure you are[ signed in](https://opencollective.com/signin?next=%2F) with the email address you used to process the transaction.
-2. Go to the page for the Collective you supported
-3. Find the Budget menu
+1. Ensure you are [signed in](https://opencollective.com/signin?next=%2F) with the email address you used to process the transaction.
+2. Go to the page for the Collective you supported.
+3. Find the Budget menu.
 4. Click "Transactions." You will then have the option to View All Transactions.
 5. Use the Search Transactions box to find your name, and filter using the dropdown boxes.
-6. When you find the right contribution, you will have an option to download a PDF of your receipt.
+6. When you find the right contribution, download the PDF receipt.
 
-### Changing the details on your receipt
+## Changing the details on your receipt
 
 You can change certain details on your receipt after the contribution has been made, such as your address.
 
@@ -51,6 +51,6 @@ To do this, navigate to your Dashboard > Settings > Info, and update your detail
 
 The next time you generate a receipt, your details will automatically be updated to the new information.
 
-### Tax displayed on receipts
+## Tax displayed on receipts
 
 Receipts only show the tax amount when hosts are subject to either VAT (EU) or GST (NZ). For all other cases, this column will always display 0%


### PR DESCRIPTION
## Summary
- Document refund vs reject vs cancel recurring contribution workflows
- Update host refund modal details (allocation, negative balance, optional cancel/remove)
- Document consolidated monthly and annual receipts in Payment Receipts settings

## Pages
- `collectives/raising-money/rejecting-and-refunding-financial-contributions.md`
- `fiscal-hosts/processing-refunds.md`
- `giving-to-collectives/managing-receipts.md`
- `giving-to-collectives/making-a-recurring-contribution.md`

## Verified against
- opencollective-frontend: `HostCancelContributionModal.tsx`, `HostRefundChargeModal.tsx`, `PaymentReceipts.tsx`

## Test plan
- [ ] Read updated pages on GitBook preview
- [ ] Confirm refund/reject/cancel paths match dashboard UI
- [ ] Confirm annual receipt download steps