### PR TITLE
docs: People tool and host overview metrics

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -129,6 +129,7 @@
   * [Fiscal Host Security](fiscal-hosts/setting-up-a-fiscal-host/fiscal-host-security.md)
   * [Fiscal Host Policies](fiscal-hosts/setting-up-a-fiscal-host/fiscal-host-policies.md)
 * [Fiscal Host Overview Dashboard](fiscal-hosts/fiscal-host-overview-dashboard.md)
+* [People Tool](fiscal-hosts/people-tool.md)
 * [Managing your Collectives](fiscal-hosts/managing-your-collectives/README.md)
   * [Hosted Collectives](fiscal-hosts/managing-your-collectives/hosted-collectives.md)
   * [Collective Applications](fiscal-hosts/managing-your-collectives/collective-applications.md)

--- a/fiscal-hosts/fiscal-host-overview-dashboard.md
+++ b/fiscal-hosts/fiscal-host-overview-dashboard.md
@@ -2,19 +2,24 @@
 description: >-
   The Fiscal Host Overview Dashboard allows admins to get a quick glimpse of
   recent activity, pending items, and financial status all on one page.
-hidden: true
 icon: gauge-high
 ---
 
 # Fiscal Host Overview Dashboard
 
-The Fiscal Host Overview Dashboard provides admins with a high-level overview of their status on the platform. This includes a to-do list of pending Expenses, Contributions, and Applications; a snapshot of balance, income, and spent funds; and a short list of recent activity associated with the Host.
+The Fiscal Host Overview Dashboard provides admins with a high-level overview of their status on the platform. Open your fiscal host dashboard and select **Overview** from the sidebar.
+
+The page includes a setup guide, pending action items, financial snapshots, hosted collective and fund metrics, and a recent activity timeline.
+
+## Setup guide
+
+New hosts see a collapsible setup checklist on the Overview page. Toggle it from the settings menu in the Overview header (**Display setup guide**).
 
 ## To do
 
-The To do module in the Fiscal Host Overview consolidates all of items that might require an admin's attention in one place. Clicking on one of the buttons with a specific type of Expense, Contribution, or Application will redirect you to the respective page in the Dashboard, filtered to only show those specific items.&#x20;
+The To do module consolidates items that may need your attention. Clicking a button redirects to the relevant dashboard page, filtered to that item type.
 
-The specific items that are featured in the To do list are:
+The specific items featured in the To do list are:
 
 * Expenses
   * Unreplied
@@ -34,20 +39,49 @@ The specific items that are featured in the To do list are:
 
 ## Recent Financial Activity
 
-The Recent Financial Activity section of the Overview page shows important financial information consolidated into one place. It is also possible to change the filters for the information displayed to account for different time spans or focus exclusively on the fiannces of the Fiscal Host or its hosted Collectives.
+The Recent Financial Activity section shows balance, income, and spending in one place.
 
-There are four main components displayed in this section:
+### Filters
 
-* Balance
-* Received
-* Spent
-* Recent Transactions
+* **Context:** All, Organization, or Hosted - focus on host-level finances or hosted collectives only
+* **Period:** Today, Last 7 days, Last 4 weeks (default), Last 3 months, Last 12 months, Month/Quarter/Year to date, All time, or a custom range
 
-The information displayed can also be configured by changing the filters at the top of the section.
+### Metrics
+
+| Metric | Description |
+| ------ | ----------- |
+| Balance | End-of-period balance, including starting balance. May show comparison to period start. |
+| Received | Total received in the selected period |
+| Spent | Total spent in the selected period |
+
+### Recent transactions
+
+A preview table shows the five most recent transactions. When more transactions exist, a link opens **Ledger > Transactions** with the same period and context filters applied.
 
 <figure><img src="../.gitbook/assets/image (78).png" alt="Screen shot of the Recent Financial Activity filters."><figcaption></figcaption></figure>
 
+## Hosted Collectives and Hosted Funds
+
+Below Recent Financial Activity, two metric sections track the health of your hosted accounts. Each section has its own month picker.
+
+### Metric cards
+
+| Metric | Definition |
+| ------ | ---------- |
+| Active | At least one ledger transaction this month |
+| Inactive | Hosted but no financial activity this month |
+| Newly Hosted | Joined and approved this month |
+| Unhosted | Unhosted this month |
+
+### Top lists
+
+Each section also shows:
+
+* **Top by Amount Received**
+* **Top by Amount Spent**
+
 ## Recent Activity
 
-The final section on the Overview page is the Recent activity module. This section gives a simplified snapshot of all of the activity related to the Fiscal Host on the platform. To view a more comprehensive list of associated activities, you can click the "Got to activity log button" at the top of the section.
+The final section on the Overview page is the Recent activity module. This gives a simplified snapshot of activity related to your fiscal host, including expenses, virtual cards, contributions, updates, and collective events.
 
+To view a comprehensive list, click **Go to activity log** at the top of the section.

--- a/fiscal-hosts/know-your-customer-kyc.md
+++ b/fiscal-hosts/know-your-customer-kyc.md
@@ -3,22 +3,35 @@ description: >-
   KYC (Know Your Customer) verification is a critical process that helps
   organizations ensure compliance with regulatory requirements. It involves
   verifying the identity and legal information of account
-hidden: true
 icon: user
 ---
 
 # Know Your Customer (KYC)
 
-Use the manual KYC verification process to register on Open Collective the result of a KYC program made outside the platform, the host is responsible for ensuring the information is accurate and up-to-date.
+Use the manual KYC verification process to register on Open Collective the result of a KYC program made outside the platform. The host is responsible for ensuring the information is accurate and up-to-date.
 
-### Where to find and initiate a Manual KYC Verification
+## Where to find and initiate a Manual KYC Verification
 
-* From the people tool, in the KYC tab under an individual\`s account details. Here you can find the history of KYC verification for an individual and request a new verification.
-* From the KYC requests dashboard. Here you can review all KYC requests made by your organization and you can initiate a request by searching an individual.
-* From submitted expenses to your organization or your hosted collectives. Here you can submit a KYC verification on behalf of the payee, as well as review its current status.
-* Within the context of your dashboard, when hovering individual accounts, a KYC badge will be displayed if that individual has a pending or verified KYC request.
+### People tool
 
-### Expenses
+The [People tool](people-tool.md) is the primary place to review KYC status across individuals who interact with your organization.
+
+* **People list:** The **KYC** column shows verification status when the feature is enabled. Use the row actions menu to **Submit Manual KYC Verification** for an individual.
+* **Account detail:** Open a person from the People list and go to the **KYC** tab to view verification history and submit a new verification.
+
+### KYC Requests dashboard
+
+From **Dashboard > KYC > Requests**, review all KYC requests for your organization and initiate a request by searching for an individual.
+
+### From submitted expenses
+
+When reviewing expenses to your organization or hosted collectives, you can submit KYC verification on behalf of the payee and review current status.
+
+### KYC badges in the dashboard
+
+When hovering over individual accounts elsewhere in the dashboard, a KYC badge appears if that individual has a pending or verified KYC request.
+
+## Expenses
 
 When reviewing a submitted expense to your organization or hosted collectives, you can:
 
@@ -27,12 +40,10 @@ When reviewing a submitted expense to your organization or hosted collectives, y
 * Submit a KYC verification on behalf of the individual.
 * Review the KYC status of the payee account (collectives, projects, funds, etc). When the payee can be administrated by multiple people, we surface the KYC statuses of the admins.
 
-#### Changes to expense payout method after KYC verification
+### Changes to expense payout method after KYC verification
 
 When a payee is KYC verified, any changes to the expense payout method after the KYC verification are flagged and generate an activity in the expense timeline. Expense payers can still proceed with payment after review of the payout method.
 
-#### Flagging expense payees for KYC verification.
+### Flagging expense payees for KYC verification
 
-When a expense payee is flagged for KYC verification in the expense review process, all current and future unpaid expenses from that payee are flagged as requiring KYC verification. Expenses from this payee will appear on the "on hold" pipeline on the expense payment tool. After the payee has completed KYC, the "on hold" status will not be applied and the expense will appear on "ready to pay" (depending on the other expense conditions).
-
-#### &#x20;
+When an expense payee is flagged for KYC verification in the expense review process, all current and future unpaid expenses from that payee are flagged as requiring KYC verification. Expenses from this payee appear in the **on hold** pipeline on the expense payment tool. After the payee has completed KYC, the on hold status is removed and the expense appears as ready to pay (depending on other expense conditions).

--- a/fiscal-hosts/people-tool.md
+++ b/fiscal-hosts/people-tool.md
@@ -1,0 +1,105 @@
+---
+description: >-
+  The People tool is a fiscal host directory of individuals who interacted with
+  your organization, with account details, KYC status, and financial history.
+icon: users
+---
+
+# People Tool
+
+The People tool lists individuals who have interacted with your fiscal host or organization: collective admins, contributors, expense submitters, and payees. Use it to review roles, KYC status, and financial activity in one place.
+
+## Who can access it
+
+The **People** section appears in the dashboard sidebar for accounts with money management (fiscal hosts and self-hosted organizations). It is not available for individual accounts or accountant-only roles.
+
+Navigate to **Dashboard > People**.
+
+## The People list
+
+The page title is **People**, with the description "People that interacted with your organization."
+
+### View tabs
+
+Preset filters at the top of the list:
+
+* **All**
+* **Collective Admins**
+* **Financial Contributors**
+* **Expense Submitters**
+* **Payees**
+
+### Filters and sorting
+
+Use the filter bar to narrow results:
+
+* **Search** by name or email
+* **Relation Type** - admin, contributor, expense submitter, payee, and other roles
+* **Account** - filter by a specific hosted collective
+* **Total Contributed** and **Total Expended** - amount ranges
+* **Sort** by name, date created, total contributed, or total expended
+
+### Columns
+
+| Column | Description |
+| ------ | ----------- |
+| Account | Avatar, display name, and legal name |
+| Email | Email address with copy button |
+| KYC | Verification status (when KYC is enabled) |
+| Country | Location |
+| Roles | Relationship badges (admin, contributor, payee, etc.) |
+| Total Expenses | Amount and count of expenses |
+| Total Contributions | Amount and count of contributions |
+
+### Row actions
+
+Click the row actions menu to:
+
+* **View All Expenses** - opens the expense list filtered to this person
+* **View All Contributions** - opens Incoming Contributions filtered to this person
+* **View All Transactions** - opens host transactions filtered to this person
+* **Submit Manual KYC Verification** - available for individuals when KYC is enabled
+
+Click a row to open the account detail page.
+
+### Export
+
+Self-hosted organizations (not fiscal hosts) see an **Export Contributors** button that downloads a CSV of contributor data.
+
+## Account detail
+
+Clicking a person opens their account detail at **Dashboard > People > {account}**.
+
+### Header
+
+The header shows account type, KYC status, tax form status, and counts of rejected or spam expenses. Actions include **View Profile** and **Copy URL**.
+
+### Overview tab
+
+* **Details** - legal name, display name, email, location, social links
+* **Platform Activity** - join date, first and latest interaction, roles
+* **Administrators / Admin of** - linked admin accounts
+* **Financial metrics** - amounts received from and disbursed to this person over time
+* **Recently Received / Recently Disbursed** - preview of recent transactions
+
+### Money Movement tab
+
+Full transaction history with date, amount, search, accounting category, and hosted account filters.
+
+### Managed Disbursements tab
+
+For individuals, shows expenses this person approved, paid, or rejected. Filter by Approved, Paid, or Rejected.
+
+### Activities tab
+
+Paginated activity feed for this person relative to your organization.
+
+### KYC tab
+
+When KYC is enabled, shows verification history and a button to submit a new manual verification. See [Know Your Customer (KYC)](know-your-customer-kyc.md).
+
+## Related documentation
+
+* [Know Your Customer (KYC)](know-your-customer-kyc.md)
+* [Dashboard Navigation](dashboard-navigation.md)
+* [Vendors](managing-your-collectives/vendors.md) - separate vendor directory for organizations


### PR DESCRIPTION
## Summary
- Add People tool documentation (list, filters, account detail tabs)
- Unhide and expand fiscal host overview dashboard with HostMetricsOverview
- Expand KYC doc with People tool integration

## Pages
- `fiscal-hosts/people-tool.md` (new)
- `fiscal-hosts/fiscal-host-overview-dashboard.md`
- `fiscal-hosts/know-your-customer-kyc.md`
- `SUMMARY.md`

## Verified against
- opencollective-frontend: `People.tsx`, `AccountDetail.tsx`, `HostOverview.tsx`

## Test plan
- [ ] Read updated pages on GitBook preview
- [ ] Confirm People tool paths and tabs match UI
- [ ] Confirm host overview metrics descriptions