### PR TITLE
docs: expenses, vendors, EPC QR, permalinks, tier types

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,6 +30,7 @@
 
 * [Notifications](advanced/notifications.md)
 * [Preview Features](advanced/preview-features.md)
+* [Permalinks and Public IDs](advanced/permmlinks-and-ids.md)
 * [Activity Log](advanced/activity-log.md)
 * [Security For Accounts](advanced/security-for-accounts/README.md)
   * [Logging into your Account](advanced/security-for-accounts/logging-into-your-account.md)

--- a/advanced/permmlinks-and-ids.md
+++ b/advanced/permmlinks-and-ids.md
@@ -1,0 +1,50 @@
+---
+description: >-
+  Permalinks and public IDs let you share direct links to expenses,
+  contributions, and other records across dashboard views.
+icon: link
+---
+
+# Permalinks and Public IDs
+
+Open Collective uses short **permalinks** and **public IDs** so you can share links to specific expenses, contributions, and other records. Permalinks open the correct dashboard view based on who is signed in.
+
+## Public IDs
+
+Each record has a public ID with a type prefix:
+
+| Prefix | Record type |
+| ------ | ----------- |
+| `ex_` | Expense |
+| `or_` | Order (contribution) |
+
+You can copy a public ID from the expense header (**Copy ID** chip) or from dashboard action menus.
+
+## Permalink URLs
+
+Permalink format:
+
+```
+https://opencollective.com/permalink/{publicId}
+```
+
+Short links also work at `/id/{publicId}` and redirect to the appropriate destination.
+
+## Copy link actions
+
+In dashboard lists and detail views, use **Copy link** from the row actions menu or **More Actions**. The copied URL is a permalink that routes viewers to the right place:
+
+* **Fiscal host admins** - host expense or contribution views
+* **Collective admins** - collective payment request or contribution views
+* **Submitters** - submitted expenses or outgoing contributions
+* **Guests** - public expense page or sign-in prompt when access is required
+
+## Private accounts
+
+Permalinks to records on private accounts redirect unauthorized viewers. If you do not have permission to view a private account, you may see an access-denied page rather than the record details.
+
+See [Private Organizations](../organizations/private-organizations.md) for more on private account visibility.
+
+## Legacy URLs
+
+Older URLs using collective slugs and numeric IDs (for example `/{collective}/expenses/{id}`) may still work. Prefer permalinks when sharing links with teammates or between dashboard sections.

--- a/collectives/raising-money/setting-goals-and-tiers.md
+++ b/collectives/raising-money/setting-goals-and-tiers.md
@@ -97,13 +97,17 @@ As you set the options from the form, you will see a preview of your tier develo
 
 You can create your tier using the following options. Many of these are optional. Remember to press the “create” button once you’re ready to publish.\
 \
-**Type:** Is your tier a generic tier, or is it related to a membership, service, product or a donation?&#x20;
+**Type:** Is your tier a generic tier, or is it related to a membership, service, product or a donation?
 
-* "Generic" is the default contribution type that shows all fields as customizable entries.&#x20;
-* "Membership" is a recurring contribution where contributors get a special status, such as a right to vote on decisions.&#x20;
-* "Service" means donors get a service in return.&#x20;
+* "Generic" is the default contribution type that shows all fields as customizable entries.
+* "Membership" is a recurring contribution where contributors get a special status, such as a right to vote on decisions. Project collectives do not see Membership in the type picker.
+* "Service" means donors get a service in return.
 * "Product" is where donors get a gift or item.
-* &#x20;"Donation" is a simple contribution to the cause.&#x20;
+* "Donation" is a simple contribution to the cause.
+
+{% hint style="info" %}
+Fiscal hosts may disable certain tier types for hosted collectives. If a type is missing from the dropdown, contact your fiscal host. For events, when ticket tiers are disabled, the Tickets section shows a message and hides **Create Ticket**.
+{% endhint %}
 
 {% hint style="success" %}
 If in doubt, use the "Generic" tier.

--- a/expenses-and-getting-paid/submitting-expenses/README.md
+++ b/expenses-and-getting-paid/submitting-expenses/README.md
@@ -11,7 +11,7 @@ You can submit an expense by either [finding the Organization or Collective's pa
 
 <figure><img src="../../.gitbook/assets/image (50).png" alt="Screenshot of a Collective&#x27;s header with a red outline highlighting the location of the &#x22;Submit Expense&#x22; button on the page."><figcaption><p>Screenshot of a Collective's header with a red outline highlighting the location of the "Submit Expense" button on the page.</p></figcaption></figure>
 
-Or by navigating to your personal Dashboard > Expenses > New Expense in the top right hand corner.&#x20;
+Or by navigating to your personal Dashboard > Incoming Money > Issued Payment Requests (or **Dashboard > Expenses** without the sidebar reorganization preview) and clicking **New Expense** in the top right corner.&#x20;
 
 <figure><img src="../../.gitbook/assets/Screenshot 2025-10-28 at 5.30.03 PM.png" alt="Screenshot of your personal dashboard, expenses page. Highlighting the new expense button"><figcaption><p><sub>Screenshot of your personal dashboard, expenses page. Highlighting the new expense button</sub></p></figcaption></figure>
 
@@ -48,8 +48,19 @@ You will be asked:
 * Who is being paid (you can choose your individual account, Collective account, Organization account, Vendor, or an event or project). You can also invite someone else to submit an expense.
 
 {% hint style="info" %}
-You will need to [set up an Open Collective account](../../getting-started/setting-up-your-account.md) to submit an expense. To be paid as a company, please [set up](../../getting-started/creating-an-organization.md) and select your Organization account as the payee.
+You will need to [set up an Open Collective account](../../getting-started/setting-up-your-account.md) to submit an expense.
 {% endhint %}
+
+### Paying through a legal entity
+
+If you need to be paid as a company but do not yet have an Organization account, select **I would like to get paid through a legal entity** on the **Who is getting paid** step. You can create an Organization inline by providing:
+
+* Country of incorporation
+* Legal name and public display name
+* Profile URL slug
+* Confirmation that you are legally registered as an administrator of the entity
+
+If you already administer an Organization, select **An account I administer** instead. See [Creating an Organization](../../getting-started/creating-an-organization.md) for full organization setup outside the expense flow.
 
 ## Choose a payout method
 
@@ -135,9 +146,9 @@ Before submitting your expense, you will be asked to review all the information 
 If you need to make any changes, you can do this by clicking "Edit Expense".
 
 {% hint style="info" %}
-Once you have submitted an expense, you can find it on your public profile page, in your Dashboard > Expenses or in the Organization or Collective's budget.&#x20;
+Once you have submitted an expense, you can find it on your public profile page, in your Dashboard > Incoming Money > Issued Payment Requests (or **Dashboard > Expenses**), or in the Organization or Collective's budget.
 
-By selecting the "More Actions" menu at the bottom of the page for the expense, you can choose to edit it, download it, or copy the link to the page.
+By selecting the **More Actions** menu for the expense, you can edit it, download it, or **Copy link**. The copied link is a [permalink](../../advanced/permmlinks-and-ids.md) that opens the expense in the correct dashboard view for each viewer.
 
 Downloading an expense is only available for invoices, and not reimbursements.
 {% endhint %}

--- a/fiscal-hosts/expense-payment/paying-expenses-as-a-fiscal-host.md
+++ b/fiscal-hosts/expense-payment/paying-expenses-as-a-fiscal-host.md
@@ -27,7 +27,18 @@ For each payment processor, the card will show the balance of the corresponding 
 
 #### Expense List
 
-You can monitor the status of expenses submitted to your hosted Collectives in the “Expenses” section of your Fiscal Host’s Dashboard.
+You can monitor the status of expenses submitted to your hosted Collectives from **Dashboard > Outgoing Money**. Use these sub-pages depending on your task:
+
+| Sub-page | Use for |
+| -------- | ------- |
+| **Approve Payment Requests** | Expenses awaiting collective or host approval |
+| **Pay Disbursements** | Approved expenses ready to pay |
+| **Paid Disbursements** | Expenses already paid |
+| **All Payment Requests** | Full expense list with filters |
+
+Without the sidebar reorganization preview, these workflows appear under **Dashboard > Expenses**.
+
+Use **Copy link** from expense actions to share a [permalink](../../advanced/permmlinks-and-ids.md) with teammates. The link opens the expense in the correct dashboard view for each viewer's role.
 
 There you will see a list of expenses, which you can filter by:&#x20;
 

--- a/fiscal-hosts/expense-payment/paying-expenses-with-paypal.md
+++ b/fiscal-hosts/expense-payment/paying-expenses-with-paypal.md
@@ -82,4 +82,8 @@ Verification is **not currently mandatory** — payees can still submit expenses
 
 {% hint style="info" %}
 If you have concerns about an unverified PayPal payout method on a specific expense, you can use the "Mark as Incomplete" action to ask the payee to update their payout method before you process payment.
+
+## PayPal payout batch ID
+
+After a PayPal payout is initiated, the expense timeline shows an **Expense processing** entry with a **PayPal payout batch ID**. Use this ID to locate the payment in your PayPal Payouts dashboard for reconciliation and support requests.
 {% endhint %}

--- a/fiscal-hosts/managing-your-collectives/vendors.md
+++ b/fiscal-hosts/managing-your-collectives/vendors.md
@@ -114,7 +114,16 @@ You will not be prompted for a payment method. The payment method that is listed
 
 By default, only Fiscal Host admins are able to submit expenses to Vendors. However, you can enable expense submitters to also submit expenses to your Vendors.&#x20;
 
-To enable this, go to the Fiscal Host Dashboard > Settings > Policies. There you will find an option to enable all users to submit expenses to Vendors
+To enable this, go to the Fiscal Host Dashboard > Settings > Policies. There you will find an option to enable all users to submit expenses to Vendors.
+
+### Creating vendors inline
+
+Fiscal host admins can create vendors without leaving the expense or expected funds flow:
+
+* **Expense submission:** On the **Who is getting paid** step, select **A vendor** and type a new name in the picker. Choose **Create vendor: {name}** to create and select a vendor scoped to that collective.
+* **Add Funds / Expected Funds:** In the contributor or source picker, type a new vendor name and choose **Create vendor: {name}**.
+
+Non-host submitters (when the vendor policy is enabled) can search and select existing vendors but cannot create new ones inline. Use **Dashboard > Vendors** to manage the vendor directory.
 
 <figure><img src="../../.gitbook/assets/image (67).png" alt="Screenshot of Fiscal Host Policy settings, showing the ability to allow all users to submit expenses on behalf of Vendors."><figcaption></figcaption></figure>
 

--- a/fiscal-hosts/receiving-money/bank-transfers.md
+++ b/fiscal-hosts/receiving-money/bank-transfers.md
@@ -15,9 +15,17 @@ You can enable manual bank transfers by completing the following instructions:
 2. Under Bank Transfers, click “Set bank details”
 3. Follow the directions on the page to add in your bank account information and instructions that will be emailed to contributors when they initiate a manual bank payment.&#x20;
 
-Financial Contributors will then be able to select the 'Bank Transfer' option as a payment method. After completing the donation, they will automatically be emailed the instructions you specified outlining how to manually complete the transaction, this includes a unique transaction identifier.&#x20;
+Financial Contributors will then be able to select the 'Bank Transfer' option as a payment method. After completing the donation, they will automatically be emailed the instructions you specified outlining how to manually complete the transaction, this includes a unique transaction identifier (order reference).
 
 They then proceed to make the payment, using the code as a reference.
+
+### EPC QR code (EUR SEPA)
+
+When your bank account has **IBAN and BIC** configured and the contribution is in **EUR**, contributors also see a **Scan to pay** EPC QR code on the contribution success page (and in emailed instructions).
+
+The QR code encodes payee, IBAN, BIC, amount, and order reference for compatible European banking apps. Scanning pre-fills a SEPA credit transfer in many mobile banking apps.
+
+EPC QR codes appear only for EUR transfers when IBAN and BIC are present. Other currencies or incomplete bank details show text instructions only.
 
 This transaction shows up in the Expected Funds section in your Dashboard. It shows the amount, the contributor, and the unique ID code (order#).
 


### PR DESCRIPTION
## Summary
- Document legal-entity payee inline creation and updated expense dashboard paths
- Add inline vendor creation, EPC QR for EUR SEPA, permalinks/public IDs page
- Document PayPal batch ID on expense timeline, host tier type restrictions, Outgoing Money expense pages

## Pages
- `advanced/permmlinks-and-ids.md` (new)
- `expenses-and-getting-paid/submitting-expenses/README.md`
- `fiscal-hosts/managing-your-collectives/vendors.md`
- `fiscal-hosts/receiving-money/bank-transfers.md`
- `fiscal-hosts/expense-payment/paying-expenses-with-paypal.md`
- `fiscal-hosts/expense-payment/paying-expenses-as-a-fiscal-host.md`
- `collectives/raising-money/setting-goals-and-tiers.md`
- `SUMMARY.md`

## Verified against
- opencollective-frontend: `WhoIsGettingPaidSection.tsx`, `CustomPaymentMethodInstructions.tsx`, permalink helpers, vendor pickers, tier modals

## Test plan
- [ ] Read updated pages on GitBook preview
- [ ] Confirm EPC QR and permalink workflows
- [ ] Confirm Outgoing Money sub-page names