### PR TITLE
docs: private organizations alpha overview

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -172,6 +172,7 @@
   * [Launching an Organization](organizations/creating-an-organization/launching-an-organization.md)
   * [Migrating from Fiscal Host to an Organization](organizations/creating-an-organization/migrating-from-fiscal-host-to-an-organization.md)
 * [Managing Organization Finances](organizations/managing-organization-finances.md)
+* [Private Organizations](organizations/private-organizations.md)
 
 ## INDEPENDENT COLLECTIVES
 

--- a/organizations/private-organizations.md
+++ b/organizations/private-organizations.md
@@ -1,0 +1,51 @@
+---
+description: >-
+  Private organizations are dashboard-only accounts for groups that need
+  operational privacy while using Open Collective admin tools.
+icon: building-lock
+---
+
+# Private Organizations
+
+{% hint style="warning" %}
+**Private organizations are in alpha.** Behavior and availability may change without notice. There is **no self-serve setup flow** on the platform today. If your group is interested in private organizations, please [contact Open Collective](https://opencollective.com/contact).
+{% endhint %}
+
+## What are private organizations?
+
+Private organizations (and other private accounts) exist for groups that need to manage money and operations on Open Collective **without a public profile or contribution flow**. They are intended for dashboard-only use by authorized admins and accountants.
+
+Private accounts are not discoverable through public search or profile pages in the same way as standard collectives and organizations.
+
+## Who is this for?
+
+Private organizations are for **host admins and organization admins** who are onboarded through Open Collective. This is not a general signup path. Open Collective provisions private accounts manually after discussing requirements with your group.
+
+## What to expect once provisioned
+
+After Open Collective sets up a private account for your group, you can expect:
+
+### Dashboard access
+
+Authorized roles (admins, accountants, and host admins in your tree) can use standard dashboard tools for money management, expenses, and reporting.
+
+### No public fundraising surfaces
+
+Private accounts do not offer the same public-facing features as standard organizations:
+
+* No public contribution or checkout flow for visitors
+* No public tiers, funding goals, or profile marketing
+* No public updates or community conversations
+* No gift card flows across public profiles
+
+### Host tree rules
+
+A fiscal host tree cannot mix public and private hosted accounts. If a host is private, its hosted children are private as well. Private accounts cannot bridge expenses or added funds across different fiscal host trees.
+
+### Restricted visibility
+
+Only authorized users can view private account details. Others who follow a direct link may see an access-denied response rather than account information.
+
+## Getting started
+
+There is no button or settings page to enable private organizations yourself. To discuss whether private organizations fit your needs, [contact Open Collective](https://opencollective.com/contact).


### PR DESCRIPTION
## Summary
- Add private organizations overview page with prominent alpha disclaimer
- No self-serve setup documented; interested groups must contact Open Collective
- Describes dashboard-only expectations and host tree constraints

## Pages
- `organizations/private-organizations.md` (new)
- `SUMMARY.md`

## Verified against
- opencollective-api: `docs/private-organizations.md`
- opencollective-frontend: private account UI gates in `menu-items.ts`

## Test plan
- [ ] Read page on GitBook preview
- [ ] Confirm alpha warning is prominent
- [ ] Confirm no self-serve setup steps are documented