### PR TITLE
Document optional public profile for users and vendors

### DIFF
--- a/fiscal-hosts/managing-your-collectives/vendors.md
+++ b/fiscal-hosts/managing-your-collectives/vendors.md
@@ -8,11 +8,13 @@ icon: briefcase-blank
 
 # Vendors
 
-A vendor represents an external entity which Fiscal Hosts can attribute contributions or expenses to. Vendors have no public profile and are only able to be created and edited by Fiscal Host Admins.
+A vendor represents an external entity which Fiscal Hosts can attribute contributions or expenses to. By default, vendors have no public profile and are only able to be created and edited by Fiscal Host Admins.
+
+{% hint style="info" %}
+**New:** Vendors can now optionally enable a **Contributor Profile** to showcase their activity on the platform as contributors to collectives. This is disabled by default and can be enabled when creating or editing a vendor.
+{% endhint %}
 
 Navigate to your Fiscal Host Dashboard and select Vendors.
-
-
 
 ## Review Existing Vendors
 
@@ -28,27 +30,28 @@ You can create a Vendor by clicking on “Create Vendor”
 
 You will then be prompted to provide the following Vendor information:
 
-* Image (optional)
-* Vendor's Name
-* Vendor's Legal Name (optional)
-* Tax Form (optional)
-  * Tax Form URL (optional)
-* Tax Identification
-  * Identification System (optional)
-  * ID Number (optional)
-* Mailing Address (optional)
-* Contact Name (optional)
-* Contact's email (optional)
-* Payout method (optional)
-* Notes (optional)
+- Image (optional)
+- Vendor's Name
+- Vendor's Legal Name (optional)
+- Contributor Profile (optional)
+  - When enabled, the vendor will have a public profile page displaying their contributions to collectives
+  - When disabled (default), the vendor has no public presence and only appears in host admin views
+- Tax Form (optional)
+  - Tax Form URL (optional)
+- Tax Identification
+  - Identification System (optional)
+  - ID Number (optional)
+- Contact Name (optional)
+- Contact's email (optional)
+- Mailing Address (optional)
+- Payout method (optional)
+- Notes (optional)
 
 <details>
 
 <summary>Screenshot of Create Vendor modal</summary>
 
 <figure><img src="../../.gitbook/assets/image (60).png" alt="Screenshot of the &#x22;Create Vendor&#x22; modal. "><figcaption></figcaption></figure>
-
-
 
 </details>
 
@@ -78,8 +81,6 @@ You can view all archived Vendors in the archived tab. Within this view, you can
 
 <figure><img src="../../.gitbook/assets/image (64).png" alt="Screenshot of Archived Vendor settings with Unarchive option showing. "><figcaption></figcaption></figure>
 
-
-
 ## Assign Contributions to Vendors
 
 When creating contributions (through either added funds or pending contributions) you can attribute the contribution to a Vendor by typing in the Vendor's name.&#x20;
@@ -89,8 +90,6 @@ When creating contributions (through either added funds or pending contributions
 You can also create a new Vendor by simply entering a Vendor name and clicking Create Vendor.
 
 You can add additional Vendor information via the Vendor settings in your Fiscal Host dashboard.
-
-
 
 ## Vendor availability
 
@@ -108,8 +107,6 @@ Once submitting an expense you can attribute it to a selected Vendor by searchin
 
 You will not be prompted for a payment method. The payment method that is listed for the Vendor in the Vendor settings will be used to process the payment.
 
-
-
 ## Enable Other Expense Submitters to Submit Expenses on Behalf of Vendors
 
 By default, only Fiscal Host admins are able to submit expenses to Vendors. However, you can enable expense submitters to also submit expenses to your Vendors.&#x20;
@@ -120,8 +117,8 @@ To enable this, go to the Fiscal Host Dashboard > Settings > Policies. There you
 
 Fiscal host admins can create vendors without leaving the expense or expected funds flow:
 
-* **Expense submission:** On the **Who is getting paid** step, select **A vendor** and type a new name in the picker. Choose **Create vendor: {name}** to create and select a vendor scoped to that collective.
-* **Add Funds / Expected Funds:** In the contributor or source picker, type a new vendor name and choose **Create vendor: {name}**.
+- **Expense submission:** On the **Who is getting paid** step, select **A vendor** and type a new name in the picker. Choose **Create vendor: {name}** to create and select a vendor scoped to that collective.
+- **Add Funds / Expected Funds:** In the contributor or source picker, type a new vendor name and choose **Create vendor: {name}**.
 
 Non-host submitters (when the vendor policy is enabled) can search and select existing vendors but cannot create new ones inline. Use **Dashboard > Vendors** to manage the vendor directory.
 

--- a/getting-started/editing-your-profile-page.md
+++ b/getting-started/editing-your-profile-page.md
@@ -13,13 +13,36 @@ This is automatically created. Navigate to your Dashboard > Settings > Info to a
 
 This page will include your:
 
-* Display name&#x20;
-* Your short description&#x20;
-* An avatar&#x20;
-* Your cover image
+- Display name&#x20;
+- Your short description&#x20;
+- An avatar&#x20;
+- Your cover image
 
 {% hint style="info" %}
 You can also edit your info for your Collective, Fiscal Host, or Organization similarly.
+{% endhint %}
+
+### Public Profile Visibility (Individual Users)
+
+As an individual user, you can control whether your public profile page is visible to others on the platform.
+
+Navigate to **Dashboard > Settings > Info**, and scroll to the **Profile Details** section. You'll find a **Public profile** toggle that allows you to:
+
+- **Enable** (default): Your profile page is publicly accessible and displays your activity and contributions
+- **Disable**: Your public profile page is hidden from visitors
+
+{% hint style="info" %}
+When you disable your public profile, the profile page itself becomes hidden, but your activity remains visible throughout the platform:
+
+- Your contributions to collectives will still be shown
+- Your role as a core member of organizations will still be displayed
+- Your name will appear in transaction histories and expense records
+
+Disabling the public profile only hides the dedicated profile page at `opencollective.com/your-handle`.
+{% endhint %}
+
+{% hint style="warning" %}
+This setting is different from [Private Organizations](../organizations/private-organizations.md), which are special dashboard-only accounts with no public-facing features at all.
 {% endhint %}
 
 ### Adding images to your profile

--- a/organizations/private-organizations.md
+++ b/organizations/private-organizations.md
@@ -33,10 +33,10 @@ Authorized roles (admins, accountants, and host admins in your tree) can use sta
 
 Private accounts do not offer the same public-facing features as standard organizations:
 
-* No public contribution or checkout flow for visitors
-* No public tiers, funding goals, or profile marketing
-* No public updates or community conversations
-* No gift card flows across public profiles
+- No public contribution or checkout flow for visitors
+- No public tiers, funding goals, or profile marketing
+- No public updates or community conversations
+- No gift card flows across public profiles
 
 ### Host tree rules
 
@@ -45,6 +45,14 @@ A fiscal host tree cannot mix public and private hosted accounts. If a host is p
 ### Restricted visibility
 
 Only authorized users can view private account details. Others who follow a direct link may see an access-denied response rather than account information.
+
+{% hint style="info" %}
+**Note:** Private organizations are different from users or vendors with disabled public profiles.
+
+- **Private organizations**: Fully private accounts with no public-facing features at all. Dashboard-only access for authorized users.
+- **Disabled public profile** (individual users): The profile page is hidden, but activity remains visible as a contributor to collectives and as a member of organizations.
+- **Vendors with contributor profile disabled**: Standard vendor behavior—no public profile page, only visible in host admin views. When enabled, vendors can showcase their contributions on a public profile page.
+  {% endhint %}
 
 ## Getting started
 


### PR DESCRIPTION
Reflects changes from opencollective-frontend commit 988f0658c8:
- Users can now disable/enable their public profile via Dashboard > Settings > Info
- Vendors can optionally enable a contributor profile to showcase platform activity
- Clarifies distinction between disabled profiles and private organizations

Updates:
- getting-started/editing-your-profile-page.md: Added Public Profile Visibility section
- fiscal-hosts/managing-your-collectives/vendors.md: Added Contributor Profile option
- organizations/private-organizations.md: Clarified differences between account types